### PR TITLE
Actually verify the signatures and raise an exception if invalid.

### DIFF
--- a/uma/__tests__/test_uma.py
+++ b/uma/__tests__/test_uma.py
@@ -337,3 +337,22 @@ def test_lnurlp_response_create_and_parse() -> None:
         verify_uma_lnurlp_response_signature(
             result_response, receiver_signing_public_key_bytes
         )
+
+def test_invalid_lnurlp_signature() -> None:
+    sender_signing_private_key_bytes, _ = _create_key_pair()
+    _, different_signing_key_public = _create_key_pair()
+
+    receiver_address = "bob@vasp2.com"
+    lnurlp_request_url = create_lnurlp_request_url(
+        signing_private_key=sender_signing_private_key_bytes,
+        receiver_address=receiver_address,
+        sender_vasp_domain="vasp1.com",
+        is_subject_to_travel_rule=True,
+    )
+    lnurlp_request = parse_lnurlp_request(lnurlp_request_url)
+
+    # test invalid signature
+    with pytest.raises(InvalidSignatureException):
+        verify_uma_lnurlp_query_signature(
+            lnurlp_request, different_signing_key_public
+        )

--- a/uma/__tests__/test_uma.py
+++ b/uma/__tests__/test_uma.py
@@ -338,6 +338,7 @@ def test_lnurlp_response_create_and_parse() -> None:
             result_response, receiver_signing_public_key_bytes
         )
 
+
 def test_invalid_lnurlp_signature() -> None:
     sender_signing_private_key_bytes, _ = _create_key_pair()
     _, different_signing_key_public = _create_key_pair()
@@ -353,6 +354,4 @@ def test_invalid_lnurlp_signature() -> None:
 
     # test invalid signature
     with pytest.raises(InvalidSignatureException):
-        verify_uma_lnurlp_query_signature(
-            lnurlp_request, different_signing_key_public
-        )
+        verify_uma_lnurlp_query_signature(lnurlp_request, different_signing_key_public)

--- a/uma/uma.py
+++ b/uma/uma.py
@@ -101,10 +101,12 @@ def _verify_signature(payload: bytes, signature: str, signing_pubkey: bytes) -> 
 
     key = _load_public_key(signing_pubkey)
     try:
-        key.verify(
+        did_verify = key.verify(
             signature=bytes.fromhex(signature),
             message=payload,
         )
+        if not did_verify:
+            raise InvalidSignature()
     except (ValueError, InvalidSignature) as ex:
         raise InvalidSignatureException() from ex
 


### PR DESCRIPTION
The key.verify function just returns a boolean.