### PR TITLE
Tweak conversion mechanics to be more explicit and safe.

### DIFF
--- a/uma/currency.py
+++ b/uma/currency.py
@@ -10,7 +10,8 @@ from uma.JSONable import JSONable
 class Currency(JSONable):
     code: str
     """
-    ISO 4217 currency code. For example, USD for US Dollars.
+    ISO 4217 currency code (if applicable). For example, USD for US Dollars. For cryptocurrencies, this will
+    be a ticker symbol, such as BTC for Bitcoin.
     """
 
     name: str
@@ -23,7 +24,7 @@ class Currency(JSONable):
     Symbol for this currency. For example, in USD, the symbol is "$".
     """
 
-    millisatoshi_per_unit: int
+    millisatoshi_per_unit: float
     """
     Estimated millisats per smallest "unit" of this currency (eg. 1 cent in USD).
     """
@@ -40,13 +41,15 @@ class Currency(JSONable):
     (eg. cents for USD).
     """
 
-    decimals: Optional[int]
+    decimals: int
     """
-    Number of digits after the decimal point for display on the sender side. For example,
-    in USD, by convention, there are 2 digits for cents - $5.95. in this case, `decimals`
-    would be 2. Note that the multiplier is still always in the smallest unit (cents). This field
-    is only for display purposes. The sender should assume zero if this field is omitted, unless
-    they know the proper display format of the target currency.
+    The number of digits after the decimal point for display on the sender side, and to add clarity
+	around what the "smallest unit" of the currency is. For example, in USD, by convention, there are 2 digits for
+	cents - $5.95. In this case, `decimals` would be 2. Note that the multiplier is still always in the smallest
+	unit (cents). In addition to display purposes, this field can be used to resolve ambiguity in what the multiplier
+	means. For example, if the currency is "BTC" and the multiplier is 1000, really we're exchanging in SATs, so
+	`decimals` would be 8.
+	For details on edge cases and examples, see https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md.
     """
 
     @classmethod

--- a/uma/currency.py
+++ b/uma/currency.py
@@ -1,7 +1,7 @@
 # Copyright ©, 2022-present, Lightspark Group, Inc. - All Rights Reserved
 
 from dataclasses import dataclass
-from typing import Dict, Optional
+from typing import Dict
 
 from uma.JSONable import JSONable
 

--- a/uma/exceptions.py
+++ b/uma/exceptions.py
@@ -19,6 +19,8 @@ class UnsupportedVersionException(Exception):
 class InvalidRequestException(Exception):
     pass
 
+class InvalidCurrencyException(Exception):
+    pass
 
 class InvalidSignatureException(Exception):
     def __init__(self) -> None:

--- a/uma/exceptions.py
+++ b/uma/exceptions.py
@@ -19,8 +19,10 @@ class UnsupportedVersionException(Exception):
 class InvalidRequestException(Exception):
     pass
 
+
 class InvalidCurrencyException(Exception):
     pass
+
 
 class InvalidSignatureException(Exception):
     def __init__(self) -> None:

--- a/uma/version.py
+++ b/uma/version.py
@@ -6,7 +6,7 @@ from functools import total_ordering
 from typing import List, Optional
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 1
+MINOR_VERSION = 2
 UMA_PROTOCOL_VERSION = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 
 


### PR DESCRIPTION
- Make the decimals field on `Currency` required and change its description to include more details about its use.
- Change the multiplier field from int to float to allow for very small unit currencies. See https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md for details on why this is needed.

NOTE: This is technically a breaking change. Given that we're not yet at UMA 1.0, I'm bumping the protocol version here to 0.2 to indicate the bump and to be able to tell what version the counterparty is using for debugging.