### PR TITLE
A couple small changes to payment_info in the payreq response.

### DIFF
--- a/uma/__tests__/test_uma.py
+++ b/uma/__tests__/test_uma.py
@@ -226,8 +226,9 @@ def test_pay_req_response_create_and_parse() -> None:
         ),
     )
 
-    msats_per_currency_unit = 34_150
+    msats_per_currency_unit = 24_150
     receiver_fees_msats = 2_000
+    currency_decimals = 2
     receiver_utxos = ["abcdef12345"]
     receiver_utxo_callback = "/receiver_api/lnurl/utxocallback?txid=1234"
     receiver_node_pubkey = "dummy_pub_key"
@@ -237,6 +238,7 @@ def test_pay_req_response_create_and_parse() -> None:
         invoice_creator=invoice_creator,
         metadata=_create_metadata(),
         currency_code=currency_code,
+        currency_decimals=currency_decimals,
         msats_per_currency_unit=msats_per_currency_unit,
         receiver_fees_msats=receiver_fees_msats,
         receiver_utxos=receiver_utxos,
@@ -250,6 +252,7 @@ def test_pay_req_response_create_and_parse() -> None:
     assert response.compliance.utxos == receiver_utxos
     assert response.compliance.node_pubkey == receiver_node_pubkey
     assert response.payment_info.currency_code == currency_code
+    assert response.payment_info.decimals == currency_decimals
     assert response.payment_info.multiplier == msats_per_currency_unit
     assert response.payment_info.exchange_fees_msats == receiver_fees_msats
 

--- a/uma/protocol.py
+++ b/uma/protocol.py
@@ -134,8 +134,31 @@ class PayReqResponseCompliance(JSONable):
 @dataclass
 class PayReqResponsePaymentInfo(JSONable):
     currency_code: str
-    multiplier: int
+    """
+    The currency code that the receiver will receive for this payment.
+    """
+
+    decimals: int
+    """
+    Number of digits after the decimal point for the receiving currency. For example, in USD, by
+    convention, there are 2 digits for cents - $5.95. In this case, `decimals` would be 2. This should align with
+    the currency's `decimals` field in the LNURLP response. It is included here for convenience. See
+    [UMAD-04](https://github.com/uma-universal-money-address/protocol/blob/main/umad-04-lnurlp-response.md) for
+    details, edge cases, and examples.
+    """
+
+    multiplier: float
+    """
+    The conversion rate. It is the number of millisatoshis that the receiver will receive for 1
+    unit of the specified currency (eg: cents in USD). In this context, this is just for convenience. The conversion
+    rate is also baked into the invoice amount itself. Specifically:
+    `invoiceAmount = amount * multiplier + exchangeFeesMillisatoshi`
+    """
+
     exchange_fees_msats: int
+    """
+    The fees charged (in millisats) by the receiving VASP for this transaction. This is separate from the `multiplier`.
+    """
 
     @classmethod
     def _get_field_name_overrides(cls) -> Dict[str, str]:

--- a/uma/version.py
+++ b/uma/version.py
@@ -6,7 +6,7 @@ from functools import total_ordering
 from typing import List, Optional
 
 MAJOR_VERSION = 0
-MINOR_VERSION = 2
+MINOR_VERSION = 3
 UMA_PROTOCOL_VERSION = f"{MAJOR_VERSION}.{MINOR_VERSION}"
 
 


### PR DESCRIPTION
- Add the decimals field to payreq paymentinfo for convenience.
- Make the multiplier here a float to match the Currency object in the lnurlp response.
- Bump version to 0.3 since these are breaking changes.

Protocol change: https://github.com/uma-universal-money-address/protocol/pull/14