### PR TITLE
Fix version future-proofing with is_uma_lnurlp_query.

### DIFF
--- a/uma/__tests__/test_uma.py
+++ b/uma/__tests__/test_uma.py
@@ -152,6 +152,15 @@ def test_lnurlp_query_missing_params() -> None:
     assert not is_uma_lnurlp_query(url)
 
 
+def test_lnurlp_query_unsupported_version() -> None:
+    url = "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&isSubjectToTravelRule=true&timestamp=12345678&umaVersion=10.0"
+    assert is_uma_lnurlp_query(url)
+
+    # Imagine if we removed the travel rule field and nonce field in a future version:
+    url = "https://vasp2.com/.well-known/lnurlp/bob?signature=signature&vaspDomain=vasp1.com&umaVersion=10.0&timestamp=12345678"
+    assert is_uma_lnurlp_query(url)
+
+
 def test_lnurlp_query_invalid_path() -> None:
     url = "https://vasp2.com/.well-known/lnurla/bob?signature=signature&nonce=12345&vaspDomain=vasp1.com&umaVersion=0.1&isSubjectToTravelRule=true&timestamp=12345678"
     assert not is_uma_lnurlp_query(url)


### PR DESCRIPTION
Future versions of UMA may change fields in this request, etc. so treating a parse failure as "non-uma" isn't the right behavior. We should allow the parsing to spit up the proper UnsupportedVersion exception later. This was causing the demo vasp to treat v1 requests as regular lnurl, rather than negotiating a lower UMA version.