### PR TITLE
Avoid defaulting to SAT for empty sending currency.

### DIFF
--- a/uma/__tests__/test_uma.py
+++ b/uma/__tests__/test_uma.py
@@ -856,6 +856,8 @@ def test_payreq_serialization_in_msats() -> None:
         payer_email=None,
         payer_compliance=None,
     )
+    assert pay_request.amount == amount_msats
+    assert pay_request.sending_amount_currency_code is None
     payreq_json = json.loads(pay_request.to_json())
     assert payreq_json["amount"] == amount_msats
     assert payreq_json["convert"] == "USD"

--- a/uma/protocol/v1/payreq.py
+++ b/uma/protocol/v1/payreq.py
@@ -78,7 +78,7 @@ class PayRequest(JSONable):
             result_dict["convert"] = receiving_currency
         result_dict["amount"] = (
             f"{result_dict['amount']}.{sending_currency}"
-            if sending_currency and sending_currency.upper() != "SAT"
+            if sending_currency is not None
             else result_dict["amount"]
         )
         return result_dict


### PR DESCRIPTION
In practice, it's actually msats, not sats. This breaks the amount of the created invoice.