### PR TITLE
Use the payeedata identifier for signature verification.

### DIFF
--- a/uma/__tests__/test_uma.py
+++ b/uma/__tests__/test_uma.py
@@ -368,7 +368,7 @@ def test_pay_req_response_create_and_parse() -> None:
     assert payment_info.exchange_fees_msats == receiver_fees_msats
     verify_pay_req_response_signature(
         sender_address="$alice@vasp1.com",
-        receiver_address="$bob@vasp2.com",
+        receiver_address="$Bob@vasp2.com",
         response=response,
         other_vasp_pubkeys=receiver_pubkey_response,
         nonce_cache=nonce_cache,

--- a/uma/uma.py
+++ b/uma/uma.py
@@ -606,9 +606,12 @@ def verify_pay_req_response_signature(
         raise InvalidRequestException(
             "Signatures were added to payreq responses in UMA v1. This response is from an UMA v0 receiving VASP."
         )
-    
+
     payee_data_identifier = payee_data.get("identifier")
-    if payee_data_identifier is not None and payee_data_identifier.lower() != receiver_address.lower():
+    if (
+        payee_data_identifier is not None
+        and payee_data_identifier.lower() != receiver_address.lower()
+    ):
         raise InvalidRequestException(
             f"Payee data identifier {payee_data_identifier} does not match receiver address {receiver_address}."
         )

--- a/uma/uma.py
+++ b/uma/uma.py
@@ -605,13 +605,21 @@ def verify_pay_req_response_signature(
         raise InvalidRequestException(
             "Signatures were added to payreq responses in UMA v1. This response is from an UMA v0 receiving VASP."
         )
+    
+    payee_data_identifier = response.payee_data.get("identifier")
+    if payee_data_identifier is not None and payee_data_identifier.lower() != receiver_address.lower():
+        raise InvalidRequestException(
+            f"Payee data identifier {payee_data_identifier} does not match receiver address {receiver_address}."
+        )
+    if payee_data_identifier is None:
+        payee_data_identifier = receiver_address
 
     nonce_cache.check_and_save_nonce(
         none_throws(compliance_data.signature_nonce),
         _parse_timestamp(none_throws(compliance_data.signature_timestamp)),
     )
     _verify_signature(
-        compliance_data.signable_payload(sender_address, receiver_address),
+        compliance_data.signable_payload(sender_address, payee_data_identifier),
         none_throws(compliance_data.signature),
         other_vasp_pubkeys.get_signing_pubkey(),
     )

--- a/uma/uma.py
+++ b/uma/uma.py
@@ -593,7 +593,8 @@ def verify_pay_req_response_signature(
     other_vasp_pubkeys: PubkeyResponse,
     nonce_cache: INonceCache,
 ) -> None:
-    if not response.payee_data:
+    payee_data = response.payee_data
+    if not payee_data:
         raise InvalidRequestException(
             "Missing payee data in response. Cannot verify signature."
         )
@@ -606,7 +607,7 @@ def verify_pay_req_response_signature(
             "Signatures were added to payreq responses in UMA v1. This response is from an UMA v0 receiving VASP."
         )
     
-    payee_data_identifier = response.payee_data.get("identifier")
+    payee_data_identifier = payee_data.get("identifier")
     if payee_data_identifier is not None and payee_data_identifier.lower() != receiver_address.lower():
         raise InvalidRequestException(
             f"Payee data identifier {payee_data_identifier} does not match receiver address {receiver_address}."


### PR DESCRIPTION
This is important mainly to ensure that case-insensitivity is allowed in signatures like this.