### PR TITLE
add fiLegalEntityName to counterparty data options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.5.6
+- Add financial legal entity name to `CounterpartyDataKeys` enum.
+
 ## 1.5.5
 
 - Add country of residence and phone number to `CounterpartyDataKeys` enum.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = uma-sdk
-version = 1.5.5
+version = 1.5.6
 description = Python SDK for UMA (universal money address)
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/uma/protocol/counterparty_data.py
+++ b/uma/protocol/counterparty_data.py
@@ -43,9 +43,12 @@ class CounterpartyDataKeys(Enum):
     PHONE_NUMBER = "phoneNumber"
     """The counterparty's phone number, in E.164 format"""
 
+    FI_LEGAL_ENTITY_NAME = "fiLegalEntityName"
+    """The counterparty financial institution's legal entity name"""
+
 
 def create_counterparty_data_options(
-    options: Dict[str, bool]
+    options: Dict[str, bool],
 ) -> CounterpartyDataOptions:
     return {
         key: CounterpartyDataOption(mandatory=value) for key, value in options.items()


### PR DESCRIPTION
Updates the SDK by adding a new argument, `fi_legal_entity_name`​ to the `create_pay_request`​ helper function.